### PR TITLE
Fix TW-72903: correctly handle commands with quotes and spaces (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,32 @@ Otherwise, your component may be not loaded.
  
 See TeamCity documentation for details on plugin development.
 
+### Kotlin DSL descriptor
+`kotlin-dsl/SBT.xml` describes the generated TeamCity Kotlin DSL API for the SBT runner. 
+It defines the DSL build step type, class and function descriptions, parameter names, parameter descriptions, options,
+and examples that Kotlin DSL users see in generated DSL documentation and IDE assistance.
+
+The file is copied into the plugin ZIP under `kotlin-dsl/SBT.xml` by `build/plugin-assembly.xml`.
+TeamCity consumes it as a DSL descriptor, not as the build step edit UI. The contents of `<description>`
+elements are XML text and should be written as Markdown/KDoc-style documentation text. 
+Existing descriptions already use Markdown-style links. 
+Use Markdown block syntax, including blank lines before lists, when rendered line breaks or lists matter.
+
+### Server module
+`tc-sbt-runner-server` is the TeamCity server-side part of the plugin. It is built as a JAR and packaged
+under the plugin ZIP `server` directory. It depends on TeamCity server APIs and `server-web-api`, and it
+contains the server extension classes plus the JSP resources used by the TeamCity web UI.
+
+The module is wired through `tc-sbt-runner-server/src/main/resources/META-INF/build-server-plugin-tc-sbt-runner.xml`.
+That Spring descriptor registers:
+- `SbtRunnerRunType`, which registers the SBT runner type, default parameters, validation, displayed
+  parameter summary, and paths to the edit/view JSP files.
+- `SbtRunnerDiscoveryExtension`, which lets TeamCity suggest the SBT runner when `.sbt` files are found.
+
+The UI resources live in `tc-sbt-runner-server/src/main/resources/buildServerResources`:
+- `editSbtRunParams.jsp` is displayed on the TeamCity build step edit page. It is processed as JSP and rendered as HTML in the browser.
+- `viewSbtRunParams.jsp` is displayed on the read-only build step parameters view.
+
 ## IDE setup
 Open the root `pom.xml` as a Maven project in IntelliJ IDEA. Maven is the source of truth for modules,
 dependencies, repositories, and compiler settings; generated `.iml` files and local IDEA import state are

--- a/kotlin-dsl/SBT.xml
+++ b/kotlin-dsl/SBT.xml
@@ -24,8 +24,24 @@
 
         <param name="sbt.args" dslName="commands">
             <description>
-                Commands to execute, e.g. 'clean compile test' or
-                ';clean;set scalaVersion:="2.11.6";compile;test' for commands containing quotes.
+                Commands to execute.
+                Whitespace-separated arguments are treated as separate sbt commands.
+                Quote a whole command when it contains spaces using `'...'` or `"..."`.
+                Examples:
+                   - `clean compile test` (runs 3 commands)
+                   - `'set scalaVersion := "3.8.3"'` (runs 1 command)
+                   - `"testOnly example.Test1 example.Test2"` (runs 1 command)
+                   - `"testOnly example.Test1" "testOnly example.Test2"` (runs 2 commands)
+                   - `"testOnly example.Test -- -t \"specific test\""` (runs 1 command)
+                      (notice that the test case name escapes quotes as the command is inside quotes already)
+
+                An alternative to using quotes can be using `;`.
+                If a semicolon is detected in the input outside the quoted content, the input is treated as an sbt command chain.
+                The leading `;` is optional.
+                Examples:
+                   - `clean ; set scalaVersion:="2.11.6" ; compile ; test` (sbt will run 4 commands)
+                   - `;clean;compile;test` (sbt will run 3 commands)
+                   - `"set name :=\"name with ; inside\""` (sbt runs 1 command, `;` is part of the quoted content)
             </description>
         </param>
 

--- a/tc-sbt-runner-agent/src/main/kotlin/jetbrains/buildServer/sbt/SbtCommandFileContentBuilder.kt
+++ b/tc-sbt-runner-agent/src/main/kotlin/jetbrains/buildServer/sbt/SbtCommandFileContentBuilder.kt
@@ -1,0 +1,27 @@
+package jetbrains.buildServer.sbt
+
+object SbtCommandFileContentBuilder {
+
+    @JvmStatic
+    fun build(sbtCommands: String, prologueCommands: List<String> = emptyList()): String {
+        val preparedArgs = prepareArgs(sbtCommands)
+        val prologCommandsText = if (prologueCommands.isEmpty())
+            ""
+        else
+            prologueCommands.joinToString(separator = " ") { ";$it" } + " "
+        return prologCommandsText + preparedArgs
+    }
+
+    @JvmStatic
+    fun prepareArgs(sbtCommands: String): String {
+        if (sbtCommands.startsWith(";")) {
+            return sbtCommands
+        }
+        return sbtCommands
+            .split(" ")
+            .asSequence()
+            .map(String::trim)
+            .filter(String::isNotEmpty)
+            .joinToString(separator = "") { "\n; $it" }
+    }
+}

--- a/tc-sbt-runner-agent/src/main/kotlin/jetbrains/buildServer/sbt/SbtCommandFileContentBuilder.kt
+++ b/tc-sbt-runner-agent/src/main/kotlin/jetbrains/buildServer/sbt/SbtCommandFileContentBuilder.kt
@@ -1,27 +1,98 @@
 package jetbrains.buildServer.sbt
 
+import jetbrains.buildServer.util.StringUtil
+
 object SbtCommandFileContentBuilder {
 
+    /**
+     * Builds the text written to sbt's redirected command file.
+     *
+     * Inferred historical intent: print the user commands from a new line for better visibility of the
+     * commands in the TeamCity build output.
+     *
+     * Example:
+     * ```
+     * ; apply -cp "/agent temp/tc_plugin/sbt-teamcity-logger.jar" jetbrains.buildServer.sbtlogger.SbtTeamCityLogger ; sbt-teamcity-logger
+     * ; clean
+     * ; testOnly example.Test -- -t "specific test"
+     * ```
+     */
     @JvmStatic
     fun build(sbtCommands: String, prologueCommands: List<String> = emptyList()): String {
         val preparedArgs = prepareArgs(sbtCommands)
-        val prologCommandsText = if (prologueCommands.isEmpty())
-            ""
-        else
-            prologueCommands.joinToString(separator = " ") { ";$it" } + " "
-        return prologCommandsText + preparedArgs
+        val prologCommandsText = prologueCommands.asSequence().joinWithSemicolon(separator = " ")
+        val separator = if (prologCommandsText.isEmpty() || preparedArgs.isEmpty()) "" else "\n"
+        return prologCommandsText + separator + preparedArgs
     }
 
+    /**
+     * Converts the TeamCity `SBT commands:` field into commands for sbt's redirected command-file mode.
+     *
+     * The field is intentionally close to, but not exactly, a terminal prompt.
+     *
+     * Space-separated input such as `clean compile test` is treated like `sbt clean compile test`:
+     * each shell word becomes a separate sbt command.
+     *
+     * Quoted input such as `"testOnly Foo -- -z \"name\""` is treated like one shell-quoted sbt argument,
+     * so the surrounding quotes group the command and are not sent to sbt.
+     *
+     * Raw semicolon chains are the compatibility exception.
+     * TeamCity accepts `;clean;compile;test` directly because the field is not parsed by a shell;
+     * in a terminal the same chain would need quoting, for example `sbt ';clean;compile;test'`.
+     *
+     * The command file remains an implementation detail that lets the runner
+     * prepend TeamCity logger setup commands before feeding the user's commands to sbt.
+     */
     @JvmStatic
     fun prepareArgs(sbtCommands: String): String {
-        if (sbtCommands.startsWith(";")) {
-            return sbtCommands
+        val trimmedArgs = sbtCommands.trim()
+        if (trimmedArgs.startsWith(";")) {
+            return trimmedArgs
         }
-        return sbtCommands
-            .split(" ")
-            .asSequence()
+        if (containsSemicolonOutsideQuotes(sbtCommands)) {
+            return ";$trimmedArgs"
+        }
+
+        val commandsNormalised: Sequence<String> = splitCommandArgumentsAndUnquoteAll(sbtCommands)
+            // The inner content of command arguments can contain escaped double quotes
+            // Example: "testOnly org.MyTest -- -t \"my test name\"
+            .map(::unescapeDoubleQuotes)
             .map(String::trim)
             .filter(String::isNotEmpty)
-            .joinToString(separator = "") { "\n; $it" }
+        return commandsNormalised.joinWithSemicolon(separator = "\n")
     }
+
+    private fun containsSemicolonOutsideQuotes(text: String): Boolean =
+        StringUtil.splitHonorQuotes(" $text ", ';').size > 1
+
+    /**
+     * Similar to [[StringUtil.splitCommandArgumentsAndUnquote]] but keeps single-quoted and double-quoted runner input equivalent.
+     *
+     * [StringUtil.splitCommandArgumentsAndUnquote] uses both quote characters for grouping but removes
+     * only surrounding double quotes (") from the returned tokens.
+     * The SBT runner treats surrounding single quotes as the same kind of command grouping,
+     * so strip them here and unescape inner double quotes left by quoted command input.
+     */
+    private fun splitCommandArgumentsAndUnquoteAll(text: String): Sequence<String> =
+        StringUtil.splitCommandArgumentsAndUnquote(text)
+            .asSequence()
+            .map(::unquoteSingleQuote)
+
+    private fun unescapeDoubleQuotes(token: String): String {
+        return token.replace("\\\"", "\"")
+    }
+
+    private fun unquoteSingleQuote(token: String): String {
+        val isWithSingleQuotes = token.length >= 2 && token.first() == '\'' && token.last() == '\''
+        val result = if (isWithSingleQuotes)
+            token.substring(1, token.lastIndex)
+        else
+            token
+        return result
+    }
+
+    // Input  : Seq(one, two, tree), separator = " "
+    // Output : one ; two ; tree
+    private fun Sequence<String>.joinWithSemicolon(separator: String): String =
+        joinToString(separator = separator) { "; $it" }
 }

--- a/tc-sbt-runner-agent/src/main/kotlin/jetbrains/buildServer/sbt/SbtCommandFileContentBuilder.kt
+++ b/tc-sbt-runner-agent/src/main/kotlin/jetbrains/buildServer/sbt/SbtCommandFileContentBuilder.kt
@@ -6,9 +6,7 @@ object SbtCommandFileContentBuilder {
 
     /**
      * Builds the text written to sbt's redirected command file.
-     *
-     * Inferred historical intent: print the user commands from a new line for better visibility of the
-     * commands in the TeamCity build output.
+     * It prints the user commands from a new line for better visibility of the commands in the TeamCity build output.
      *
      * Example:
      * ```
@@ -28,17 +26,42 @@ object SbtCommandFileContentBuilder {
     /**
      * Converts the TeamCity `SBT commands:` field into commands for sbt's redirected command-file mode.
      *
-     * The field is intentionally close to, but not exactly, a terminal prompt.
-     *
-     * Space-separated input such as `clean compile test` is treated like `sbt clean compile test`:
-     * each shell word becomes a separate sbt command.
+     * The field is intentionally similar to the terminal prompt but is not exactly the same.
+     * For example simple space-separated input such as `clean compile test` is effectively treated like `sbt clean compile test`.
+     * Each shell word becomes a separate sbt command. This is effectively equivilent to `sbt ";clean;compile;test`:
+     * ```
+     * Input: `clean compile test`
+     * Output:
+     *  ; clean
+     *  ; compile
+     *  ; test
+     * ```
      *
      * Quoted input such as `"testOnly Foo -- -z \"name\""` is treated like one shell-quoted sbt argument,
      * so the surrounding quotes group the command and are not sent to sbt.
+     * Other input is split into commands, each on a new line:
+     * ```
+     * Input:  `clean "testOnly example.Test -- -t \"specific test\""`
+     * Output:
+     * ; clean
+     * ; testOnly example.Test -- -t "specific test"
+     * ```
      *
      * Raw semicolon chains are the compatibility exception.
      * TeamCity accepts `;clean;compile;test` directly because the field is not parsed by a shell;
      * in a terminal the same chain would need quoting, for example `sbt ';clean;compile;test'`.
+     *
+     * Already semicolon-prefixed input is trimmed and returned unchanged:
+     * ```
+     * Input:  ` ;clean;compile `
+     * Output: `;clean;compile`
+     * ```
+     *
+     * An input containing a semicolon outside quotes receives a leading semicolon:
+     * ```
+     * Input:  `clean;compile`
+     * Output: `;clean;compile`
+     * ```
      *
      * The command file remains an implementation detail that lets the runner
      * prepend TeamCity logger setup commands before feeding the user's commands to sbt.
@@ -66,7 +89,7 @@ object SbtCommandFileContentBuilder {
         StringUtil.splitHonorQuotes(" $text ", ';').size > 1
 
     /**
-     * Similar to [[StringUtil.splitCommandArgumentsAndUnquote]] but keeps single-quoted and double-quoted runner input equivalent.
+     * Similar to [StringUtil.splitCommandArgumentsAndUnquote] but keeps single-quoted and double-quoted runner input equivalent.
      *
      * [StringUtil.splitCommandArgumentsAndUnquote] uses both quote characters for grouping but removes
      * only surrounding double quotes (") from the returned tokens.

--- a/tc-sbt-runner-agent/src/main/kotlin/jetbrains/buildServer/sbt/SbtRunnerBuildService.kt
+++ b/tc-sbt-runner-agent/src/main/kotlin/jetbrains/buildServer/sbt/SbtRunnerBuildService.kt
@@ -223,22 +223,24 @@ class SbtRunnerBuildService(
         get() = ivyCacheProvider.cacheDir.absolutePath
 
     fun getCommands(sbtVersion: SBTVersion): List<String> {
-        val args = runnerParameters[SbtRunnerConstants.SBT_ARGS_PARAM]?.trim().orEmpty()
-        if (StringUtil.isEmpty(args)) {
+        val sbtCommands = runnerParameters[SbtRunnerConstants.SBT_ARGS_PARAM]?.trim().orEmpty()
+        if (StringUtil.isEmpty(sbtCommands)) {
             logger.warning("No commands specified.")
             return emptyList()
         }
-        return getCommandsFromFile(args, sbtVersion)
+        return getCommandsFromFile(sbtCommands, sbtVersion)
     }
 
-    private fun getCommandsFromFile(args: String, sbtVersion: SBTVersion): List<String> =
+    private fun getCommandsFromFile(sbtCommands: String, sbtVersion: SBTVersion): List<String> =
         try {
             val file = FileUtil.createTempFile(agentTempDirectory, "commands", ".file", true)
-            val content = String.format(
-                INFILE_COMMANDS_FORMATTER,
+            val prologueCommands = listOf(
                 getApplyCommand(sbtVersion),
                 getCheckStatusCommand(),
-                prepareArgs(args),
+            )
+            val content = SbtCommandFileContentBuilder.build(
+                sbtCommands,
+                prologueCommands,
             )
             val name = file.absolutePath
             logger.activityStarted("Prepare SBT run", "Write commands to file.", BUILD_ACTIVITY_TYPE)
@@ -251,18 +253,6 @@ class SbtRunnerBuildService(
             LOG.warn(e.message, e)
             emptyList()
         }
-
-    private fun prepareArgs(args: String): String {
-        if (args.startsWith(";")) {
-            return args
-        }
-        return args
-            .split(" ")
-            .asSequence()
-            .map(String::trim)
-            .filter(String::isNotEmpty)
-            .joinToString(separator = "") { "\n; $it" }
-    }
 
     override fun afterProcessFinished() {
         super.afterProcessFinished()
@@ -324,7 +314,6 @@ class SbtRunnerBuildService(
         private const val SBT_1_0_PATCH_FOLDER_NAME = "1.0"
         private const val SBT_DISTRIB = "sbt-distrib"
         private const val SBT_AUTO_HOME_FOLDER = "agent-sbt"
-        private const val INFILE_COMMANDS_FORMATTER = ";%s ;%s %s"
         private const val RUN_INFILE_COMMANDS_FORMATTER = "< %s"
         private const val SBT_INSTALLATION_STEP_NAME = "SBT installation"
         private const val SBT_TEAMCITY_LOGGER_INSTALLATION = "SBT TeamCity logger installation"
@@ -348,5 +337,8 @@ class SbtRunnerBuildService(
         )
 
         private const val SBT_PATCH_CLASS_NAME = "jetbrains.buildServer.sbtlogger.SbtTeamCityLogger"
+
+        @JvmStatic
+        fun prepareArgs(args: String): String = SbtCommandFileContentBuilder.prepareArgs(args)
     }
 }

--- a/tc-sbt-runner-common/src/main/kotlin/jetbrains/buildServer/sbt/SbtRunnerConstants.kt
+++ b/tc-sbt-runner-common/src/main/kotlin/jetbrains/buildServer/sbt/SbtRunnerConstants.kt
@@ -6,6 +6,7 @@ object SbtRunnerConstants {
     const val RUNNER_DESCRIPTION = "Runs SBT builds"
 
     const val SBT_HOME_PARAM = "sbt.home"
+    // Q: rename "args" to "commands"?
     const val SBT_ARGS_PARAM = "sbt.args"
     const val SBT_INSTALLATION_MODE_PARAM = "sbt.installationMode"
 

--- a/tc-sbt-runner-server/src/main/resources/buildServerResources/editSbtRunParams.jsp
+++ b/tc-sbt-runner-server/src/main/resources/buildServerResources/editSbtRunParams.jsp
@@ -11,7 +11,35 @@
         </th>
         <td>
             <props:textProperty name="sbt.args" className="longField" expandable="true"/>
-            <span class="smallNote">Commands to execute, e.g. <i>clean compile test</i> or <i>;clean;set scalaVersion:="2.11.6";compile;test</i> for commands containing quotes</span>
+            <div class="smallNote">
+                <p>Commands to execute.</p>
+                <p>
+                    Whitespace-separated arguments are treated as separate sbt commands.<br>
+                    Quote a whole command when it contains spaces using <code>'...'</code> or <code>"..."</code>.
+                </p>
+                <p>Examples:</p>
+                <ul style="margin: 0.25em 0; padding-left: 1.5em;">
+                    <li><code>clean compile test</code> (runs 3 commands).</li>
+                    <li><code>'set scalaVersion := "3.8.3"'</code> (runs 1 command).</li>
+                    <li><code>"testOnly example.Test1 example.Test2"</code> (runs 1 command).</li>
+                    <li><code>"testOnly example.Test1" "testOnly example.Test2"</code> (runs 2 commands).</li>
+                    <li>
+                        <code>"testOnly example.Test -- -t \"specific test\""</code> (runs 1 command)
+                        (notice that the test case name escapes quotes as the command is inside quotes already).
+                    </li>
+                </ul>
+                <p>
+                    An alternative to using quotes can be using <code>;</code>.<br>
+                    If a semicolon is detected in the input outside the quoted content, the input is treated as an sbt command chain.<br>
+                    The leading <code>;</code> is optional.
+                </p>
+                <p>Examples:</p>
+                <ul style="margin: 0.25em 0; padding-left: 1.5em;">
+                    <li><code>clean ; set scalaVersion:="2.11.6" ; compile ; test</code> (sbt will run 4 commands).</li>
+                    <li><code>;clean;compile;test</code> (sbt will run 3 commands).</li>
+                    <li><code>"set name :=\"name with ; inside\""</code> (sbt runs 1 command, <code>;</code> is part of the quoted content).</li>
+                </ul>
+            </div>
         </td>
     </tr>
     <tr>
@@ -56,4 +84,3 @@
     <props:editJavaHome/>
     <props:editJvmArgs/>
 </l:settingsGroup>
-

--- a/tests/src/test/kotlin/jetbrains/buildServer/sbt/test/agent/commandBuilder/RepoPaths.kt
+++ b/tests/src/test/kotlin/jetbrains/buildServer/sbt/test/agent/commandBuilder/RepoPaths.kt
@@ -6,7 +6,7 @@ import java.io.File
  * Contains paths to common dirs in the current repository that are needed in some tests
  */
 internal object RepoPaths {
-    /** Repository root, resolved from either the root itself or the tests module working directory. */
+
     val root: File by lazy {
         val workingDirectory = File("").absoluteFile
 

--- a/tests/src/test/kotlin/jetbrains/buildServer/sbt/test/agent/commandBuilder/RepoPaths.kt
+++ b/tests/src/test/kotlin/jetbrains/buildServer/sbt/test/agent/commandBuilder/RepoPaths.kt
@@ -1,0 +1,26 @@
+package jetbrains.buildServer.sbt.test.agent.commandBuilder
+
+import java.io.File
+
+/**
+ * Contains paths to common dirs in the current repository that are needed in some tests
+ */
+internal object RepoPaths {
+    /** Repository root, resolved from either the root itself or the tests module working directory. */
+    val root: File by lazy {
+        val workingDirectory = File("").absoluteFile
+
+        // Depending on form where the tests are launched (from the root of form the subproject)
+        // current working dir can point to the subproject, so we might need to get a parent dir
+        val rootDirectory = if (File(workingDirectory, "tc-sbt-runner-agent").isDirectory)
+            workingDirectory
+        else
+            workingDirectory.parentFile
+
+        rootDirectory.canonicalFile
+    }
+
+    val testsModule: File = File(root, "tests")
+
+    val sbtLauncher: File = File(root, "tc-sbt-runner-agent/src/main/resources/sbt-distrib/sbt-launch.jar")
+}

--- a/tests/src/test/kotlin/jetbrains/buildServer/sbt/test/agent/commandBuilder/SbtProcessRunner.kt
+++ b/tests/src/test/kotlin/jetbrains/buildServer/sbt/test/agent/commandBuilder/SbtProcessRunner.kt
@@ -1,0 +1,107 @@
+package jetbrains.buildServer.sbt.test.agent.commandBuilder
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+internal object SbtProcessRunner {
+
+    @Throws(SbtProcessTimeoutException::class)
+    fun runWithCommandsFile(
+        runDirectory: File,
+        cacheDir: File,
+        commandsFile: File,
+        timeout: Duration = 2.minutes
+    ): SbtProcessResult {
+        val commandsFileAbsolutePath = commandsFile.absolutePath.replace('\\', '/')
+        val sbtArguments = listOf("""< "$commandsFileAbsolutePath"""")
+        return run(runDirectory, cacheDir, sbtArguments, timeout)
+    }
+
+    @Throws(SbtProcessTimeoutException::class)
+    fun run(
+        runDirectory: File,
+        cacheDir: File,
+        sbtArguments: List<String>,
+        timeout: Duration = 2.minutes
+    ): SbtProcessResult {
+        val sbtRunConfiguration = SbtProcessRunConfiguration(
+            javaExecutable = File(System.getProperty("java.home"), "bin/java"),
+            sbtLauncher = RepoPaths.sbtLauncher,
+            workingDirectory = runDirectory,
+            globalBaseDirectory = File(runDirectory, "sbt-global"),
+            bootDirectory = File(cacheDir, "boot"),
+            ivyHome = File(cacheDir, "ivy"),
+            outputFile = File(runDirectory, "sbt-output.log"),
+            timeout = timeout,
+            sbtArguments = sbtArguments
+        )
+        return run(sbtRunConfiguration)
+    }
+
+    private fun run(configuration: SbtProcessRunConfiguration): SbtProcessResult {
+        val process = start(configuration)
+
+        if (!process.waitFor(configuration.timeout.inWholeSeconds, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+            process.waitFor(PROCESS_DESTROY_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+
+            throw SbtProcessTimeoutException(
+                timeout = configuration.timeout,
+                output = configuration.outputFile.readText(Charsets.UTF_8),
+            )
+        }
+
+        return SbtProcessResult(
+            exitCode = process.exitValue(),
+            output = configuration.outputFile.readText(Charsets.UTF_8),
+        )
+    }
+
+    private fun start(configuration: SbtProcessRunConfiguration): Process {
+        val processBuilder = ProcessBuilder()
+        processBuilder
+            .command(
+                configuration.javaExecutable.absolutePath,
+                "-Dsbt.global.base=${configuration.globalBaseDirectory.absolutePath}",
+                "-Dsbt.boot.directory=${configuration.bootDirectory.absolutePath}",
+                "-Dsbt.ivy.home=${configuration.ivyHome.absolutePath}",
+                "-Dsbt.server.forcestart=true",
+                "-jar",
+                configuration.sbtLauncher.absolutePath,
+                *configuration.sbtArguments.toTypedArray(),
+            )
+            .directory(configuration.workingDirectory)
+            .redirectErrorStream(true)
+            .redirectOutput(configuration.outputFile)
+        return processBuilder.start()
+    }
+
+    private const val PROCESS_DESTROY_TIMEOUT_SECONDS = 5L
+}
+
+/**
+ * Contains all parameters needed to run an sbt process (working dir, arguments, launcher path, etc...)
+ */
+internal data class SbtProcessRunConfiguration(
+    val javaExecutable: File,
+    val sbtLauncher: File,
+    val workingDirectory: File,
+    val globalBaseDirectory: File,
+    val bootDirectory: File,
+    val ivyHome: File,
+    val outputFile: File,
+    val timeout: Duration,
+    val sbtArguments: List<String>,
+)
+
+internal data class SbtProcessResult(
+    val exitCode: Int,
+    val output: String,
+)
+
+internal class SbtProcessTimeoutException(
+    val timeout: Duration,
+    val output: String,
+) : RuntimeException("sbt process timed out after $timeout")

--- a/tests/src/test/kotlin/jetbrains/buildServer/sbt/test/agent/commandBuilder/SbtRunnerBuildServiceCommandParsingIntegrationTest.kt
+++ b/tests/src/test/kotlin/jetbrains/buildServer/sbt/test/agent/commandBuilder/SbtRunnerBuildServiceCommandParsingIntegrationTest.kt
@@ -1,0 +1,258 @@
+package jetbrains.buildServer.sbt.test.agent.commandBuilder
+
+import jetbrains.buildServer.sbt.SbtCommandFileContentBuilder
+import jetbrains.buildServer.sbt.test.agent.commandBuilder.SbtRunnerBuildServiceCommandParsingIntegrationTest.Companion.Markers.PAYLOAD_MARKER
+import org.testng.Assert
+import org.testng.Reporter
+import org.testng.annotations.Test
+import java.io.File
+
+/**
+ * End-to-end coverage for command files produced by [jetbrains.buildServer.sbt.SbtCommandFileContentBuilder].
+ *
+ * Each scenario runs real sbt twice:
+ * 1. with direct sbt arguments that represent what a terminal shell would pass after parsing quotes and whitespace
+ * 2. with the command file generated from the TeamCity runner input.
+ *
+ * A lightweight command-file parsing & formatting coverage is located in [SbtRunnerBuildServiceCommandsTest]
+ *
+ * Add cases here when the generated file needs to be checked against real sbt behavior.
+ *
+ * @see SbtRunnerBuildServiceCommandsTest
+ */
+class SbtRunnerBuildServiceCommandParsingIntegrationTest {
+
+    companion object {
+        private object Markers {
+            const val PRINT_INPUT_USAGE_MARKER = "printInputArg usage"
+
+
+            // ATTENTION: should be the same as in tests/testdata/commandParsing/build.sbt
+            private const val PAYLOAD_MARKER = "##tc-sbt-runner-payload##"
+
+            /**
+             * The fixture commands prefix relevant output with [PAYLOAD_MARKER]e so [extractPayloadLines] can ignore unrelated sbt log lines.
+             * This test assumes only commands from the command-parsing fixture emit that marker.
+             */
+            fun extractPayloadLines(sbtProcessOutput: String): List<String> {
+                val lines = sbtProcessOutput.lineSequence().map(String::trim)
+                val linesWithPayload = lines.filter { it.startsWith(PAYLOAD_MARKER) }
+                return linesWithPayload.map { it.removePrefix(PAYLOAD_MARKER).trimStart() }.toList()
+            }
+        }
+
+        private val commandParsingSbtProject: File = File(RepoPaths.testsModule, "testdata/commandParsing")
+        private val commandParsingTarget: File = File(RepoPaths.testsModule, "target/sbt-command-parsing")
+        private val commandParsingCache: File = File(commandParsingTarget, "cache")
+    }
+
+    @Test
+    fun `simple commands separated with spaces`() = assertSuccessfulCommand(
+        runnerInput = "printNumber printNumber",
+        directSbtArguments = listOf("printNumber", "printNumber"),
+        expectedPayload = listOf("123", "123"),
+    )
+
+    @Test
+    fun `double quoted command with spaces`() = assertSuccessfulCommand(
+        runnerInput = """ "printInputArg arg1" """,
+        directSbtArguments = listOf("printInputArg arg1"),
+        expectedPayload = listOf("arg1"),
+    )
+
+    @Test
+    fun `single quoted command with spaces`() = assertSuccessfulCommand(
+        runnerInput = "'printInputArg arg1 arg2'",
+        directSbtArguments = listOf("printInputArg arg1 arg2"),
+        expectedPayload = listOf("arg1 arg2"),
+    )
+
+    @Test
+    fun `mixed simple and quoted commands`() = assertSuccessfulCommand(
+        runnerInput = """printNumber "printInputArg quoted value" printNumber""",
+        directSbtArguments = listOf("printNumber", "printInputArg quoted value", "printNumber"),
+        expectedPayload = listOf("123", "quoted value", "123"),
+    )
+
+    @Test
+    fun `leading semicolon chain`() = assertSuccessfulCommand(
+        runnerInput = ";printNumber;printInputArg semicolon value;printNumber",
+        directSbtArguments = listOf("printNumber", "printInputArg semicolon value", "printNumber"),
+        expectedPayload = listOf("123", "semicolon value", "123"),
+    )
+
+    @Test
+    fun `inline semicolon without leading semicolon`() = assertSuccessfulCommand(
+        runnerInput = "printNumber;printInputArg inline-value",
+        directSbtArguments = listOf("printNumber", "printInputArg inline-value"),
+        expectedPayload = listOf("123", "inline-value"),
+    )
+
+    @Test
+    fun `semicolon chain with quoted assignment`() = assertSuccessfulCommand(
+        runnerInput = """;set scalaVersion:="2.12.21";printNumber""",
+        directSbtArguments = listOf("""set scalaVersion:="2.12.21"""", "printNumber"),
+        expectedPayload = listOf("123"),
+    )
+
+    @Test
+    fun `unquoted argument form`() = assertFailingCommand(
+        runnerInput = "printInputArg hello",
+        directSbtArguments = listOf("printInputArg", "hello"),
+    )
+
+    @Test
+    fun `mixed split after valid command`() = assertFailingCommand(
+        runnerInput = "printNumber printInputArg hello",
+        directSbtArguments = listOf("printNumber", "printInputArg", "hello"),
+    )
+
+    /**
+     * Runs the same scenario through direct sbt [directSbtArguments] and through the
+     * runner-generated command file built by [jetbrains.buildServer.sbt.SbtCommandFileContentBuilder], then verifies both
+     * executions succeed and produce the same [expectedPayload].
+     *
+     * @param runnerInput Raw value of the TeamCity `SBT commands:` UI field, converted into a command file.
+     * @param directSbtArguments Equivalent direct sbt argv used as the behavioral baseline.
+     * @param expectedPayload Unmarked output lines that identify the relevant successful command effects.
+     */
+    private fun assertSuccessfulCommand(
+        runnerInput: String,
+        directSbtArguments: List<String>,
+        expectedPayload: List<String>,
+    ) {
+        val name = currentTestName()
+        val baseline = runSbtDirectly(name, SbtRunVariant.BASELINE, directSbtArguments)
+        Assert.assertEquals(
+            baseline.exitCode,
+            0,
+            "Baseline sbt run failed for '$name'.\n${baseline.output}",
+        )
+
+        val actual = runSbtWithCommandFile(name, SbtRunVariant.RUNNER, SbtCommandFileContentBuilder.build(runnerInput))
+        Assert.assertEquals(
+            actual.exitCode,
+            0,
+            "Runner-style sbt run failed for '$name'.\n${actual.output}",
+        )
+
+        val baselinePayload = Markers.extractPayloadLines(baseline.output)
+        val actualPayload = Markers.extractPayloadLines(actual.output)
+
+        Assert.assertEquals(
+            baselinePayload,
+            expectedPayload,
+            "Baseline payload did not match expected output for '$name'.\n${baseline.output}",
+        )
+        Assert.assertEquals(
+            actualPayload,
+            baselinePayload,
+            "Runner-style payload did not match direct sbt behavior for '$name'.\n" +
+                    "Actual output:\n${actual.output}\nBaseline output:\n${baseline.output}",
+        )
+    }
+
+    private fun assertFailingCommand(
+        runnerInput: String,
+        directSbtArguments: List<String>,
+    ) {
+        val name = currentTestName()
+        val baseline = runSbtDirectly(name, SbtRunVariant.BASELINE, directSbtArguments)
+        val actual = runSbtWithCommandFile(name, SbtRunVariant.RUNNER, SbtCommandFileContentBuilder.build(runnerInput))
+
+        Assert.assertNotEquals(
+            baseline.exitCode,
+            0,
+            "Baseline sbt run unexpectedly succeeded for '$name'.\n${baseline.output}",
+        )
+        Assert.assertNotEquals(
+            actual.exitCode,
+            0,
+            "Runner-style sbt run unexpectedly succeeded for '$name'.\n${actual.output}",
+        )
+        Assert.assertEquals(
+            Markers.extractPayloadLines(actual.output),
+            Markers.extractPayloadLines(baseline.output),
+            """Runner-style successful payload before failure differed from baseline for '$name'.
+              |Actual output:
+              |${actual.output}
+              |Baseline output:
+              |${baseline.output}
+              |""".trimMargin(),
+        )
+        Assert.assertTrue(
+            baseline.output.contains(Markers.PRINT_INPUT_USAGE_MARKER),
+            "Baseline failure did not contain expected marker '${Markers.PRINT_INPUT_USAGE_MARKER}'.\n${baseline.output}",
+        )
+        Assert.assertTrue(
+            actual.output.contains(Markers.PRINT_INPUT_USAGE_MARKER),
+            "Runner-style failure did not contain expected marker '${Markers.PRINT_INPUT_USAGE_MARKER}'.\n${actual.output}",
+        )
+    }
+
+    private fun currentTestName(): String {
+        val testResult = requireNotNull(Reporter.getCurrentTestResult()) {
+            "Current TestNG result is not available"
+        }
+        return testResult.method.methodName
+    }
+
+    private enum class SbtRunVariant(val directorySuffix: String) {
+        BASELINE("baseline"),
+        RUNNER("runner"),
+    }
+
+    private fun runSbtDirectly(
+        caseName: String,
+        variant: SbtRunVariant,
+        directSbtArguments: List<String>
+    ): SbtProcessResult {
+        val runDirectory = prepareRunDirectory(caseName, variant)
+        return runSbt(caseName, variant) {
+            SbtProcessRunner.run(runDirectory, commandParsingCache, directSbtArguments)
+        }
+    }
+
+    private fun runSbtWithCommandFile(
+        caseName: String,
+        variant: SbtRunVariant,
+        commandsContent: String
+    ): SbtProcessResult {
+        val runDirectory = prepareRunDirectory(caseName, variant)
+
+        val commandsFile = File(runDirectory, "commands.file")
+        commandsFile.writeText(commandsContent, Charsets.UTF_8)
+
+        return runSbt(caseName, variant) {
+            SbtProcessRunner.runWithCommandsFile(runDirectory, commandParsingCache, commandsFile)
+        }
+    }
+
+    private fun runSbt(
+        caseName: String,
+        variant: SbtRunVariant,
+        run: () -> SbtProcessResult
+    ): SbtProcessResult {
+        try {
+            return run()
+        } catch (e: SbtProcessTimeoutException) {
+            Assert.fail(
+                """sbt process timed out after ${e.timeout} for '$caseName' (${variant.directorySuffix}).
+                  |Output so far:
+                  |${e.output}
+                  |""".trimMargin(),
+            )
+            throw e
+        }
+    }
+
+    private fun prepareRunDirectory(caseName: String, variant: SbtRunVariant): File {
+        val directory = File(commandParsingTarget, "${caseName.toSafeFileName()}-${variant.directorySuffix}")
+        directory.deleteRecursively()
+        commandParsingSbtProject.copyRecursively(directory, overwrite = true)
+        return directory
+    }
+
+    private fun String.toSafeFileName(): String =
+        replace(Regex("[^A-Za-z0-9._-]+"), "_").trim('_')
+}

--- a/tests/src/test/kotlin/jetbrains/buildServer/sbt/test/agent/commandBuilder/SbtRunnerBuildServiceCommandsTest.kt
+++ b/tests/src/test/kotlin/jetbrains/buildServer/sbt/test/agent/commandBuilder/SbtRunnerBuildServiceCommandsTest.kt
@@ -1,0 +1,162 @@
+package jetbrains.buildServer.sbt.test.agent.commandBuilder
+
+import jetbrains.buildServer.sbt.SbtCommandFileContentBuilder
+import jetbrains.buildServer.sbt.SbtRunnerBuildService
+import org.testng.Assert
+import org.testng.annotations.Test
+
+/**
+ * Fast command-file formatting coverage for [jetbrains.buildServer.sbt.SbtRunnerBuildService.Companion.prepareArgs].
+ *
+ * These tests assert the generated command-file text without starting sbt. For end-to-end checks that
+ * compare the generated command file with direct sbt behavior, see [SbtRunnerBuildServiceCommandParsingIntegrationTest].
+ *
+ * @see SbtRunnerBuildServiceCommandParsingIntegrationTest
+ */
+class SbtRunnerBuildServiceCommandsTest {
+
+    @Test
+    fun prepareArgs_keeps_simple_commands_as_separate_sbt_commands() {
+        assertPrepareArgs(
+            """clean compile test""",
+            """
+            ; clean
+            ; compile
+            ; test
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun prepareArgs_keeps_semicolon_prefixed_commands_unchanged() {
+        assertPrepareArgs(
+            """;clean;set scalaVersion:="3.3.8";compile;test""",
+            """;clean;set scalaVersion:="3.3.8";compile;test""",
+        )
+    }
+
+    @Test
+    fun prepareArgs_keeps_semicolon_prefixed_commands_unchanged_with_spaces() {
+        assertPrepareArgs(
+            """; clean ; set scalaVersion := "3.3.8" ; compile ; test""",
+            """; clean ; set scalaVersion := "3.3.8" ; compile ; test""",
+        )
+    }
+
+    @Test
+    fun prepareArgs_trims_but_does_not_rewrite_semicolon_prefixed_commands() {
+        assertPrepareArgs(
+            """ ;clean;compile;test """.trimIndent(),
+            """;clean;compile;test""",
+        )
+    }
+
+    @Test
+    fun prepareArgs_adds_missing_leading_semicolon_to_semicolon_chain() {
+        assertPrepareArgs(
+            """printNumber;printInputArg inline-value""",
+            """;printNumber;printInputArg inline-value""",
+        )
+    }
+
+    @Test
+    fun prepareArgs_adds_missing_leading_semicolon_to_spaced_semicolon_chain() {
+        assertPrepareArgs(
+            """clean ; set scalaVersion:="2.11.6" ; compile ; test""",
+            """;clean ; set scalaVersion:="2.11.6" ; compile ; test""",
+        )
+    }
+
+    @Test
+    fun prepareArgs_preserves_quotes_inside_simple_command_tokens_unquoted() {
+        assertPrepareArgs(
+            """ set scalaVersion:="3.3.8" """.trimIndent(),
+            """
+            ; set
+            ; scalaVersion:="3.3.8"
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun prepareArgs_preserves_quotes_inside_simple_command_tokens() {
+        assertPrepareArgs(
+            """ "set scalaVersion := \"3.3.8\"" """.trimIndent(),
+            """
+            ; set scalaVersion := "3.3.8"
+            """.trimIndent(),
+        )
+    }
+
+    // [TW-40945](https://youtrack.jetbrains.com/issue/TW-40945)
+    @Test
+    fun prepareArgs_treats_single_quoted_commands_with_spaces_as_single_sbt_commands() {
+        assertPrepareArgs(
+            """'project toto' 'set scalaVersion := "3.3.8"' clean compile test""",
+            """
+            ; project toto
+            ; set scalaVersion := "3.3.8"
+            ; clean
+            ; compile
+            ; test
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun prepareArgs_treats_quoted_command_with_spaces_as_single_sbt_command() {
+        assertPrepareArgs(
+            """ "testOnly org.example.MyTest -- -t \"my test name\" """",
+            """
+            ; testOnly org.example.MyTest -- -t "my test name"
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun prepareArgs_keeps_semicolon_inside_quoted_command_as_part_of_command() {
+        assertPrepareArgs(
+            """ "set name :=\"name with ; inside\"" """,
+            """
+            ; set name :="name with ; inside"
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun prepareArgs_allows_mixing_simple_and_quoted_commands() {
+        assertPrepareArgs(
+            """clean "testOnly example.Test -- -t \"specific test\"" compile""",
+            """
+            ; clean
+            ; testOnly example.Test -- -t "specific test"
+            ; compile
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun build_separates_runner_prologue_from_user_commands_with_newline() {
+        val actual = SbtCommandFileContentBuilder.build(
+            sbtCommands = "clean \"testOnly example.Test -- -t \\\"specific test\\\"\"",
+            prologueCommands = listOf(
+                """apply -cp "/agent temp/tc_plugin/sbt-teamcity-logger.jar" jetbrains.buildServer.sbtlogger.SbtTeamCityLogger""",
+                "sbt-teamcity-logger",
+            ),
+        )
+
+        Assert.assertEquals(
+            actual,
+            """
+            ; apply -cp "/agent temp/tc_plugin/sbt-teamcity-logger.jar" jetbrains.buildServer.sbtlogger.SbtTeamCityLogger ; sbt-teamcity-logger
+            ; clean
+            ; testOnly example.Test -- -t "specific test"
+            """.trimIndent(),
+        )
+    }
+
+    private fun assertPrepareArgs(sbtCommandsInput: String, expectedPreparedArgs: String) {
+        val actual = SbtRunnerBuildService.prepareArgs(sbtCommandsInput.trimIndent())
+        Assert.assertEquals(actual, expectedPreparedArgs)
+    }
+}

--- a/tests/testdata/commandParsing/build.sbt
+++ b/tests/testdata/commandParsing/build.sbt
@@ -1,0 +1,13 @@
+scalaVersion := "2.12.21"
+
+val payloadMarker = "##tc-sbt-runner-payload##"
+
+commands += Command.command("printNumber") { state =>
+  println(s"$payloadMarker 123")
+  state
+}
+
+commands += Command.single("printInputArg") { (state, input) =>
+  println(s"$payloadMarker $input")
+  state
+}

--- a/tests/testdata/commandParsing/project/build.properties
+++ b/tests/testdata/commandParsing/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.12


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/TW-72903/sbt-cannot-run-sbt-quoted-commands-tasks-with-spaces

Please review this only after https://github.com/JetBrains/tc-sbt-runner/pull/23 is reviewed and merged.
The changes here are based on the changes in that review.